### PR TITLE
Demo pr

### DIFF
--- a/httpx/_multipart.py
+++ b/httpx/_multipart.py
@@ -82,16 +82,17 @@ class FileField:
         if isinstance(value, tuple):
             try:
                 filename, fileobj, content_type, headers = value  # type: ignore
-                headers = {k.title(): v for k, v in headers.items()}
-                if "Content-Type" in headers:
-                    raise ValueError(
-                        "Content-Type cannot be included in multipart headers"
-                    )
             except ValueError:
                 try:
                     filename, fileobj, content_type = value  # type: ignore
                 except ValueError:
                     filename, fileobj = value  # type: ignore
+            else:
+                headers = {k.title(): v for k, v in headers.items()}
+                if "Content-Type" in headers:
+                    raise ValueError(
+                        "Content-Type cannot be included in multipart headers"
+                    )
         else:
             filename = Path(str(getattr(value, "name", "upload"))).name
             fileobj = value

--- a/httpx/_types.py
+++ b/httpx/_types.py
@@ -89,6 +89,8 @@ FileTypes = Union[
     Tuple[Optional[str], FileContent],
     # (filename, file (or bytes), content_type)
     Tuple[Optional[str], FileContent, Optional[str]],
+    # (filename, file (or bytes), content_type, headers)
+    Tuple[Optional[str], FileContent, Optional[str], Mapping[str, str]],
 ]
 RequestFiles = Union[Mapping[str, FileTypes], Sequence[Tuple[str, FileTypes]]]
 

--- a/tests/test_multipart.py
+++ b/tests/test_multipart.py
@@ -94,9 +94,7 @@ def test_multipart_file_tuple():
     assert multipart["file"] == [b"<file content>"]
 
 
-@pytest.mark.parametrize(
-    "content_type", [None, "text/plain"]
-)
+@pytest.mark.parametrize("content_type", [None, "text/plain"])
 def test_multipart_file_tuple_headers(content_type: typing.Optional[str]):
     file_name = "test.txt"
     expected_content_type = "text/plain"
@@ -122,13 +120,18 @@ def test_multipart_file_tuple_headers(content_type: typing.Optional[str]):
         assert content == b"".join(stream)
 
 
+@pytest.mark.parametrize("content_type", [None, "text/plain"])
 @pytest.mark.parametrize(
-    "content_type", [None, "text/plain"]
+    "headers",
+    [
+        {"content-type": "text/plain"},
+        {"Content-Type": "text/plain"},
+        {"CONTENT-TYPE": "text/plain"},
+    ],
 )
-@pytest.mark.parametrize(
-    "headers", [{"content-type": "text/plain"}, {"Content-Type": "text/plain"}, {"CONTENT-TYPE": "text/plain"}]
-)
-def test_multipart_headers_include_content_type(content_type: typing.Optional[str], headers: typing.Dict[str, str]) -> None:
+def test_multipart_headers_include_content_type(
+    content_type: typing.Optional[str], headers: typing.Dict[str, str]
+) -> None:
     """Including contet-type in the multipart headers should not be allowed"""
     client = httpx.Client(transport=httpx.MockTransport(echo_request_content))
 


### PR DESCRIPTION
## PR Description

This PR introduces the ability to pass multipart headers in file uploads and includes tests to validate this functionality.

### Changes:

- **`<file>`:**
  - Added a `headers` dictionary to the constructor to allow passing multipart headers.
  - Updated how `value` is unpacked to include `headers`.
  - Introduced validation to ensure "Content-Type" is not included in multipart headers.
  - Modified the `render_headers` method to correctly encode and render the multipart headers.

- **Type Annotations:**
  - Updated the type annotations for the `FileTypes` tuple to include optional headers.

- **Tests:**
  - Added a parameterized test `test_multipart_file_tuple_headers` to ensure headers can be passed correctly.
  - Created a test `test_multipart_headers_include_content_type` to verify that including "Content-Type" in headers raises a ValueError.

- **Linting:**
  - Minor lint adjustments.
<!-- This is an auto-generated comment: release notes by Deeployed - Reviewed -->
### Summary by Reviewed

- **New Feature**: Added support for passing custom multipart headers during file uploads, excluding "Content-Type".
- **Bug Fix**: Ensured a `ValueError` is raised if "Content-Type" is included in the headers.
- **Test**: Implemented new tests to verify the correct handling and validation of multipart headers.
- **Style**: Made minor linting adjustments for improved code readability and maintainability.

These changes enhance the flexibility and robustness of file upload handling, potentially affecting existing implementations.
<!-- end of auto-generated comment: release notes by Deeployed - Reviewed -->